### PR TITLE
Fix build by upgrading SvelteKit dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "type": "module",
   "devDependencies": {
     "@sveltejs/adapter-netlify": "^3.0.2",
-    "@sveltejs/kit": "^1.30.3",
+    "@sveltejs/kit": "^2.21.2",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
-    "svelte": "^4.2.12",
-    "vite": "^5.2.0"
+    "svelte": "^5.0.0",
+    "vite": "^6.3.5"
   }
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from '@sveltejs/adapter-netlify';
-import { vitePreprocess } from '@sveltejs/kit/vite';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 export default {
   kit: {


### PR DESCRIPTION
## Summary
- upgrade `@sveltejs/kit` to `^2.21.2`
- bump `svelte` to version `^5`
- bump Vite to `^6.3.5`
- import `vitePreprocess` from the correct package

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417d0632088331bf92dfa689e6a876